### PR TITLE
🔒 [security fix] Add Nonce and Capability Checks to Post Meta Save

### DIFF
--- a/auto-url-regenerator.php
+++ b/auto-url-regenerator.php
@@ -511,6 +511,7 @@ if ( !class_exists( 'Auto_URL_Regenerator' ) ) :
 		{
 			global $post;
 			$checked = (self::is_aurg_checkbox( $post ) ) ? TRUE : FALSE;
+			wp_nonce_field( 'aurg_save_post_meta', 'aurg_nonce' );
 			?>
 				
 			<input type="radio" name="aurg_checkbox" value="0"<?php echo esc_attr(($checked) ? ' checked="checked"' : '');?>><?php _e( 'On', 'autourlregenerator' ); ?>
@@ -521,6 +522,26 @@ if ( !class_exists( 'Auto_URL_Regenerator' ) ) :
 
 		public function save_aurg_checkbox_fields( $post_id )
 		{
+			// Check if nonce is set.
+			if ( ! isset( $_POST['aurg_nonce'] ) ) {
+				return;
+			}
+
+			// Verify that the nonce is valid.
+			if ( ! wp_verify_nonce( $_POST['aurg_nonce'], 'aurg_save_post_meta' ) ) {
+				return;
+			}
+
+			// If this is an autosave, our form has not been submitted, so we don't want to do anything.
+			if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+				return;
+			}
+
+			// Check the user's permissions.
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				return;
+			}
+
 			if(isset($_POST['aurg_checkbox']) ){
 				update_post_meta($post_id, 'aurg_checkbox', sanitize_text_field($_POST['aurg_checkbox'] ) );
 			}

--- a/tests/verify_fix.php
+++ b/tests/verify_fix.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Test script to verify the security fix in save_aurg_checkbox_fields.
+ */
+
+// Mock WordPress functions
+function wp_verify_nonce($nonce, $action) {
+    if ($nonce === 'valid_nonce' && $action === 'aurg_save_post_meta') {
+        return 1;
+    }
+    return false;
+}
+
+function current_user_can($capability, $post_id) {
+    if ($capability === 'edit_post' && $post_id === 123) {
+        return true;
+    }
+    return false;
+}
+
+function update_post_meta($post_id, $meta_key, $meta_value) {
+    echo "SUCCESS: update_post_meta called for post $post_id with $meta_key = $meta_value\n";
+}
+
+function sanitize_text_field($str) {
+    return $str;
+}
+
+function __($text, $domain) {
+    return $text;
+}
+
+// Mock Auto_URL_Regenerator class or just the method
+class Mock_Auto_URL_Regenerator {
+    public function save_aurg_checkbox_fields( $post_id )
+    {
+        // Check if nonce is set.
+        if ( ! isset( $_POST['aurg_nonce'] ) ) {
+            echo "EXPECTED FAILURE: Nonce not set\n";
+            return;
+        }
+
+        // Verify that the nonce is valid.
+        if ( ! wp_verify_nonce( $_POST['aurg_nonce'], 'aurg_save_post_meta' ) ) {
+            echo "EXPECTED FAILURE: Invalid nonce\n";
+            return;
+        }
+
+        // If this is an autosave, our form has not been submitted, so we don't want to do anything.
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            echo "EXPECTED FAILURE: Doing autosave\n";
+            return;
+        }
+
+        // Check the user's permissions.
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            echo "EXPECTED FAILURE: Permission denied\n";
+            return;
+        }
+
+        if(isset($_POST['aurg_checkbox']) ){
+            update_post_meta($post_id, 'aurg_checkbox', sanitize_text_field($_POST['aurg_checkbox'] ) );
+        }
+    }
+}
+
+$aurg = new Mock_Auto_URL_Regenerator();
+
+echo "--- Test 1: No nonce ---\n";
+$_POST = array('aurg_checkbox' => '1');
+$aurg->save_aurg_checkbox_fields(123);
+
+echo "\n--- Test 2: Invalid nonce ---\n";
+$_POST = array('aurg_checkbox' => '1', 'aurg_nonce' => 'invalid');
+$aurg->save_aurg_checkbox_fields(123);
+
+echo "\n--- Test 3: Permission denied ---\n";
+$_POST = array('aurg_checkbox' => '1', 'aurg_nonce' => 'valid_nonce');
+$aurg->save_aurg_checkbox_fields(456);
+
+echo "\n--- Test 5: Valid request ---\n";
+$_POST = array('aurg_checkbox' => '1', 'aurg_nonce' => 'valid_nonce');
+$aurg->save_aurg_checkbox_fields(123);
+
+echo "\n--- Test 4: Doing autosave ---\n";
+define('DOING_AUTOSAVE', true);
+$_POST = array('aurg_checkbox' => '1', 'aurg_nonce' => 'valid_nonce');
+$aurg->save_aurg_checkbox_fields(123);


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Missing Nonce and Capability Check in Post Meta Save. The `save_aurg_checkbox_fields` function was updating post metadata without verifying the source of the request or the permissions of the user.

### ⚠️ Risk: The potential impact if left unfixed
- **CSRF (Cross-Site Request Forgery):** An attacker could trick an authenticated administrator into submitting a request that changes the `aurg_checkbox` setting for any post.
- **Broken Access Control:** Any user with access to the admin area (even those without `edit_post` capabilities for a specific post) might have been able to trigger the metadata update if they could submit the form.
- **Data Integrity:** Metadata could be overwritten with incorrect values during WordPress's background autosave process.

### 🛡️ Solution: How the fix addresses the vulnerability
- **Nonce Verification:** Added a nonce field in `insert_aurg_checkbox_field` and verification in `save_aurg_checkbox_fields` to ensure requests are intentional and come from the expected source.
- **Capability Check:** Added a check for the `edit_post` capability to ensure only authorized users can modify the post's settings.
- **Autosave Protection:** Added a check for the `DOING_AUTOSAVE` constant to prevent updates during background saves.
- **Verification:** Created a test script `tests/verify_fix.php` that mocks WordPress functions to validate that these security checks correctly handle various scenarios.

---
*PR created automatically by Jules for task [5809125250734136761](https://jules.google.com/task/5809125250734136761) started by @minesiccushe*